### PR TITLE
Added (under testing) docs feature + refactored code (split into cogs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pyvenv.cfg
 .env
 share/*
 DiscordManimatorBackup.py
+config.py

--- a/DiscordManimator.py
+++ b/DiscordManimator.py
@@ -1,210 +1,46 @@
 import asyncio
 import discord
-import docker
+import config
 import os
-import tempfile
-import re
-import io
 
 from discord.ext import commands
-from dotenv import load_dotenv
 from pathlib import Path
 
-load_dotenv()
-TOKEN = os.getenv('DISCORD_TOKEN')
 
-dockerclient = docker.from_env()
-
-bot = commands.Bot(
-    command_prefix="!",
-    description="I render simple Manim Scripts.",
-    case_insensitive=False
-)
-
-@bot.event
-async def on_ready():
-    await bot.change_presence(activity=discord.Game(name='The Waiting Game'))
-    print(f'Logged in as {bot.user.name}')
-    return
-
-@bot.command()
-async def mhelp(ctx):
-    await ctx.send("""A simple Manim rendering bot.
-
-Use the `!manimate` command to render short and simple Manim scripts.
-Code **must** be properly formatted and indented. Note that you can't animate through DM's.
-
-Supported tags:
-```
-    -t, --transparent, -i, --save_as_gif, -s, --save_last_frame
-```
-Example:
-```
-!manimate -s
-\`\`\`py
-def construct(self):
-    self.play(ReplacementTransform(Square(), Circle()))
-\`\`\`
-```
-""")
-
-@bot.command(aliases=['m'])
-@commands.guild_only()
-async def manimate(ctx, *, arg):
-
-    def construct_reply(arg):
-        if arg.startswith('```'): # empty header
-            arg = '\n' + arg
-        header, *body = arg.split('\n')
-
-        cli_flags = header.split()
-        allowed_flags = [
-            "-i", "--save_as_gif",
-            "-s", "--save_last_frame",
-            "-t", "--transparent"
-        ]
-        if not all([flag in allowed_flags for flag in cli_flags]):
-            reply_args = {"content": "You cannot pass CLI flags other than "
-                            "`-i` (`--save_as_gif`), `-s` (`--save_last_frame`), "
-                            "`-t` (`--transparent`)."}
-            return reply_args
-        else:
-            cli_flags = ' '.join(cli_flags)
-
-        body = '\n'.join(body).strip()
-
-        if body.count('```') != 2:
-            reply_args = {
-                "content": 'Your message is not properly formatted. '
-                'Your code has to be written in a code block, like so:\n'
-                '\\`\\`\\`py\nyour code here\n\\`\\`\\`'
-            }
-            return reply_args
-
-        script=re.search(
-            pattern = r"```(?:py)?(?:thon)?(.*)```",
-            string = body,
-            flags=re.DOTALL,
-        ).group(1)
-        script = script.strip()
-
-        # for convenience: allow construct-only:
-        if script.startswith('def construct(self):'):
-            script = ['class Manimation(Scene):'] + ["    " + line for line in script.split("\n")]
-        else:
-            script = script.split("\n")
-
-        script = ["from manim import *"] + script
-
-        # write code to temporary file (ideally in temporary directory)
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            scriptfile = Path(tmpdirname) / 'script.py'
-            with open(scriptfile, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(script))
-            try: # now it's getting serious: get docker involved
-                reply_args = None
-                container_stderr = dockerclient.containers.run(
-                    image="manimcommunity/manim:stable",
-                    volumes={tmpdirname: {'bind': '/manim/', 'mode': 'rw'}},
-                    command=f"timeout 120 manim -qm --disable_caching --progress_bar=none -o scriptoutput {cli_flags} /manim/script.py",
-                    user=os.getuid(),
-                    stderr=True,
-                    stdout=False,
-                    remove=True
-                )
-                if container_stderr:
-                    if len(container_stderr.decode('utf-8')) <= 1200:
-                        reply_args = {
-                            "content": "Something went wrong, here is "
-                            "what Manim reports:\n"
-                            f"```\n{container_stderr.decode('utf-8')}\n```"
+class Manim(commands.Bot):
+    def __init__(self):                     
+        manim_intents = {
+                        'guilds': True, 
+                        'members': True, 
+                        'messages': True, 
+                        'reactions': True, 
+                        'presences': True
                         }
-                    else:
-                        reply_args = {
-                            "content": "Something went wrong, here is "
-                            "what Manim reports:\n",
-                            "file": discord.File(
-                                fp=io.BytesIO(container_stderr),
-                                filename="Error.log",
-                            )
-                        }
-
-                    return reply_args
-
-            except Exception as e:
-                reply_args = {"content": f"Something went wrong: ```{e}```"}
-                raise e
-            finally:
-                if reply_args:
-                    return reply_args
-
+        intents = discord.Intents(**manim_intents)   
+        super().__init__(command_prefix = config.PREFIX,
+                         case_insensitive = False,
+                         self_bot = False,
+                         description = "Manim Community Discord Bot",                    
+                         intents = intents,
+                         help_command = None
+        )
+        for extension in os.listdir("cogs/"):
             try:
-                [outfilepath] = Path(tmpdirname).rglob('scriptoutput.*')
-            except Exception as e:
-                reply_args = {"content": "Something went wrong: no (unique) output file was produced. :cry:"}
-                raise e
-            else:
-                reply_args = {"content": "Here you go:", "file": discord.File(outfilepath)}
-            finally:
-                return reply_args
-
-    async def react_and_wait(reply):
-        await reply.add_reaction("\U0001F5D1") # Trashcan emoji
-
-        def check(reaction, user):
-            return str(reaction.emoji) == '\U0001F5D1' and user == ctx.author
-
-        try:
-            reaction, user = await bot.wait_for('reaction_add', check=check, timeout=60.0)
-        except asyncio.TimeoutError:
-            await reply.remove_reaction("\U0001F5D1", bot.user)
-        else:
-            await reply.delete()
-
-    async with ctx.typing():
-        reply_args = construct_reply(arg)
-        reply = await ctx.reply(**reply_args)
-
-    await react_and_wait(reply)
-    return
+                self.load_extension(f"cogs.{extension[:-3]}")
+            except:                
+                print(f'{extension} couldn\'t be loaded')
 
 
-@bot.command()
-@commands.guild_only()
-async def mdoc(ctx, *args):
-    if len(args) == 0:
-        await ctx.reply(
-            "Pass some manim function or class and I will find the "
-            "corresponding documentation for you. Example: `!mdoc Square`"
-        )
+
+    async def on_ready(self):
+        await self.change_presence(activity=discord.Game(name='The Waiting Game'))
+        print(f'Logged in as {self.user.name}')
         return
 
-    arg = args[0]
-    if not arg.isidentifier():
-        await ctx.reply(f"`{arg}` is not a valid identifier, no class or function can be named like that.")
-        return
 
-    try:
-        container_output = dockerclient.containers.run(
-            image="manimcommunity/manim:stable",
-            command=f"""timeout 10 python -c "import manim; assert '{arg}' in dir(manim); print(manim.{arg}.__module__ + '.{arg}')" """,
-            user=os.getuid(),
-            stderr=False,
-            stdout=True,
-            detach=False,
-            remove=True
-        )
-    except docker.errors.ContainerError as e:
-        if 'AssertionError' in e.args[0]:
-            await ctx.reply(f"I could not find `{arg}` in our documentation, sorry.")
-            return
-        await ctx.reply(f"Something went wrong: ```{e.args[0]}```")
-        return
-    
-    fqname = container_output.decode("utf-8").strip()
-    url = f"https://docs.manim.community/en/stable/reference/{fqname}.html"
-    await ctx.reply(f"Here you go: {url}")
-    return
-    
 
-bot.run(TOKEN, bot=True, reconnect=True)
+
+bot = Manim()
+bot.run(config.TOKEN, bot=True, reconnect=True)
+
+

--- a/cogs/manimate.py
+++ b/cogs/manimate.py
@@ -14,6 +14,7 @@ class Manimate(commands.Cog):
     def __init__(self, bot):        
         self.bot = bot
     
+    @commands.cooldown(2, 30, commands.BucketType.user)
     @commands.command(name = 'manimate', aliases = ['m'])
     @commands.guild_only()
     async def manimate(self, ctx, *, arg):
@@ -132,6 +133,13 @@ class Manimate(commands.Cog):
 
         await react_and_wait(reply)
         return
+
+    @commands.Cog.listener()
+    async def on_command_error(self, ctx, exc):
+        if isinstance(exc, commands.CommandOnCooldown):
+            embed = discord.Embed(title="`You are on a cooldown`", 
+                                description=f"`Please try again in {int(exc.retry_after)} seconds`")
+        await ctx.reply(embed=embed, mention_author=True)        
             
 
 def setup(bot):

--- a/cogs/manimate.py
+++ b/cogs/manimate.py
@@ -1,0 +1,138 @@
+import discord
+from discord.ext import commands
+import docker
+import tempfile
+import re
+from pathlib import Path
+import asyncio
+import os
+import io
+
+dockerclient = docker.from_env()
+
+class Manimate(commands.Cog):
+    def __init__(self, bot):        
+        self.bot = bot
+    
+    @commands.command(name = 'manimate', aliases = ['m'])
+    @commands.guild_only()
+    async def manimate(self, ctx, *, arg):
+        def construct_reply(arg):
+            if arg.startswith('```'): # empty header
+                arg = '\n' + arg
+            header, *body = arg.split('\n')
+
+            cli_flags = header.split()
+            allowed_flags = [
+                "-i", "--save_as_gif",
+                "-s", "--save_last_frame",
+                "-t", "--transparent"
+            ]
+            if not all([flag in allowed_flags for flag in cli_flags]):
+                reply_args = {"content": "You cannot pass CLI flags other than "
+                                "`-i` (`--save_as_gif`), `-s` (`--save_last_frame`), "
+                                "`-t` (`--transparent`)."}
+                return reply_args
+            else:
+                cli_flags = ' '.join(cli_flags)
+
+            body = '\n'.join(body).strip()
+
+            if body.count('```') != 2:
+                reply_args = {
+                    "content": 'Your message is not properly formatted. '
+                    'Your code has to be written in a code block, like so:\n'
+                    '\\`\\`\\`py\nyour code here\n\\`\\`\\`'
+                }
+                return reply_args
+
+            script=re.search(
+                pattern = r"```(?:py)?(?:thon)?(.*)```",
+                string = body,
+                flags=re.DOTALL,
+            ).group(1)
+            script = script.strip()
+
+            # for convenience: allow construct-only:
+            if script.startswith('def construct(self):'):
+                script = ['class Manimation(Scene):'] + ["    " + line for line in script.split("\n")]
+            else:
+                script = script.split("\n")
+
+            script = ["from manim import *"] + script
+
+            # write code to temporary file (ideally in temporary directory)
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                scriptfile = Path(tmpdirname) / 'script.py'
+                with open(scriptfile, 'w', encoding='utf-8') as f:
+                    f.write('\n'.join(script))
+                try: # now it's getting serious: get docker involved
+                    reply_args = None
+                    container_stderr = dockerclient.containers.run(
+                        image="manimcommunity/manim:stable",
+                        volumes={tmpdirname: {'bind': '/manim/', 'mode': 'rw'}},
+                        command=f"timeout 120 manim -qm --disable_caching --progress_bar=none -o scriptoutput {cli_flags} /manim/script.py",
+                        user=os.getuid(),
+                        stderr=True,
+                        stdout=False,
+                        remove=True
+                    )
+                    if container_stderr:
+                        if len(container_stderr.decode('utf-8')) <= 1200:
+                            reply_args = {
+                                "content": "Something went wrong, here is "
+                                "what Manim reports:\n"
+                                f"```\n{container_stderr.decode('utf-8')}\n```"
+                            }
+                        else:
+                            reply_args = {
+                                "content": "Something went wrong, here is "
+                                "what Manim reports:\n",
+                                "file": discord.File(
+                                    fp=io.BytesIO(container_stderr),
+                                    filename="Error.log",
+                                )
+                            }
+
+                        return reply_args
+
+                except Exception as e:
+                    reply_args = {"content": f"Something went wrong: ```{e}```"}
+                    raise e
+                finally:
+                    if reply_args:
+                        return reply_args
+
+                try:
+                    [outfilepath] = Path(tmpdirname).rglob('scriptoutput.*')
+                except Exception as e:
+                    reply_args = {"content": "Something went wrong: no (unique) output file was produced. :cry:"}
+                    raise e
+                else:
+                    reply_args = {"content": "Here you go:", "file": discord.File(outfilepath)}
+                finally:
+                    return reply_args
+
+        async def react_and_wait(reply):
+            await reply.add_reaction("\U0001F5D1") # Trashcan emoji
+
+            def check(reaction, user):
+                return str(reaction.emoji) == '\U0001F5D1' and user == ctx.author
+
+            try:
+                reaction, user = await bot.wait_for('reaction_add', check=check, timeout=60.0)
+            except asyncio.TimeoutError:
+                await reply.remove_reaction("\U0001F5D1", bot.user)
+            else:
+                await reply.delete()
+
+        async with ctx.typing():
+            reply_args = construct_reply(arg)
+            reply = await ctx.reply(**reply_args)
+
+        await react_and_wait(reply)
+        return
+            
+
+def setup(bot):
+    bot.add_cog(Manimate(bot))                            

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -22,6 +22,7 @@ class Mdoc(commands.Cog):
                 "Remember to not add any spaces."
             ) 
         arg = args[0]
+        self.res = []
         if not arg.isidentifier():
             return await ctx.reply(f"`{arg}` is not a valid identifier, no class or function can be named like that.")     
 

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -1,0 +1,53 @@
+import discord
+from discord.ext import commands
+#from bs4 import BeautifulSoup
+from requests_html import AsyncHTMLSession
+import nest_asyncio
+
+nest_asyncio.apply()
+
+
+class Mdoc(commands.Cog):
+    def __init__(self, bot):        
+        self.bot = bot
+        self.base_link = 'https://docs.manim.community/'
+        self.res = []
+
+    @commands.command(name = 'mdoc')
+    async def mdocs(self, ctx, *args):
+        if len(args) == 0 or len(args) > 1:
+            return await ctx.reply(
+                "Pass some manim function or class and I will find the "
+                "corresponding documentation for you. Example: `!mdoc Square`"
+                "Remember to not add any spaces."
+            ) 
+        arg = args[0]
+        if not arg.isidentifier():
+            return await ctx.reply(f"`{arg}` is not a valid identifier, no class or function can be named like that.")     
+
+        query_url = f'https://docs.manim.community/en/stable/search.html?q={arg}&check_keywords=yes&area=default#'
+        try:
+            session = AsyncHTMLSession()
+            response = await session.get(query_url)
+        except:
+            return await ctx.send('`Failed to Establish Connection. Try again Later!`')            
+        else:
+            await response.html.arender(sleep=2)
+            about = response.html.find('.search', first=True)
+            a = about.find('li')
+            for i in range(2):
+                self.res.append(f'[`{a[i].text}`]({self.base_link + str(a[i].find("a")[0].text)})')                
+            
+        if self.res == []:            
+            self.title = '`No Results Found`'
+        else:
+            self.title = f'`Results for: {arg}`'
+
+        embed = discord.Embed(title = self.title, 
+                            description = '\n'.join(self.res),
+                            color = 0xe8e3e3)
+
+        return await ctx.reply(embed = embed, mention_author=False)                            
+
+def setup(bot):
+    bot.add_cog(Mdoc(bot))                            

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -45,7 +45,7 @@ class Mdoc(commands.Cog):
                 self.title = f'`Results for: {arg}`'
 
             for i in range(pages):
-                desc = f'[`{a[i].text}`]({self.base_link + str(a[i].find("a")[0].text).replace(" ", "%20")})'
+                desc = f'[`{a[i].text}`]({str(list(a[i].find("a")[0].absolute_links)[0])})'
                 embed = discord.Embed(title = self.title, 
                                     description = desc,
                                     color = 0xe8e3e3)

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -50,4 +50,4 @@ class Mdoc(commands.Cog):
         return await ctx.reply(embed = embed, mention_author=False)                            
 
 def setup(bot):
-    bot.add_cog(Mdoc(bot))                            
+    bot.add_cog(Mdoc(bot))

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -13,6 +13,7 @@ class Mdoc(commands.Cog):
         self.base_link = 'https://docs.manim.community/'
         self.res = []
 
+    @commands.cooldown(2, 30, commands.BucketType.user)
     @commands.command(name = 'mdoc')
     async def mdocs(self, ctx, *args):
         if len(args) == 0 or len(args) > 1:
@@ -35,6 +36,7 @@ class Mdoc(commands.Cog):
             return await ctx.send('`Failed to Establish Connection. Try again Later!`')            
         else:
             await response.html.arender(sleep=2)
+            await session.close()
             about = response.html.find('.search', first=True)
             a = about.find('li')
             pages = len(a)
@@ -49,8 +51,7 @@ class Mdoc(commands.Cog):
                 embed = discord.Embed(title = self.title, 
                                     description = desc,
                                     color = 0xe8e3e3)
-                self.res.append(embed)                
-
+                self.res.append(embed)                            
             cur_page = 0                
             reply_embed = await ctx.reply(embed = self.res[cur_page], mention_author = False)
             await reply_embed.add_reaction("◀️")
@@ -75,6 +76,13 @@ class Mdoc(commands.Cog):
 
                 except asyncio.TimeoutError:
                     await reply_embed.clear_reactions()
+
+    @commands.Cog.listener()
+    async def on_command_error(self, ctx, exc):
+        if isinstance(exc, commands.CommandOnCooldown):
+            embed = discord.Embed(title="`You are on a cooldown`", 
+                                description=f"`Please try again in {int(exc.retry_after)} seconds`")
+        await ctx.reply(embed=embed, mention_author=True)        
                                 
                               
 

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -56,11 +56,12 @@ class Mdoc(commands.Cog):
             reply_embed = await ctx.reply(embed = self.res[cur_page], mention_author = False)
             await reply_embed.add_reaction("◀️")
             await reply_embed.add_reaction("▶️")
+            await reply_embed.add_reaction("\U0001F5D1")
 
             while True:
                 try:
                     reaction, user = await self.bot.wait_for("reaction_add", 
-                                                        check = lambda reaction, user: user == ctx.author and str(reaction.emoji) in ["◀️", "▶️"],
+                                                        check = lambda reaction, user: user == ctx.author and str(reaction.emoji) in ["◀️", "▶️", "\U0001F5D1"],
                                                         timeout = 60)
                     if str(reaction.emoji) == "▶️" and cur_page != pages:
                         cur_page += 1
@@ -71,6 +72,9 @@ class Mdoc(commands.Cog):
                         cur_page -= 1
                         await reply_embed.edit(embed = self.res[cur_page])
                         await reply_embed.remove_reaction(reaction, ctx.author)
+
+                    elif str(reaction.emoji) == "\U0001F5D1":
+                        await reply_embed.delete()
                     else:
                         await reply_embed.remove_reaction(reaction, ctx.author)
 
@@ -82,7 +86,9 @@ class Mdoc(commands.Cog):
         if isinstance(exc, commands.CommandOnCooldown):
             embed = discord.Embed(title="`You are on a cooldown`", 
                                 description=f"`Please try again in {int(exc.retry_after)} seconds`")
-        await ctx.reply(embed=embed, mention_author=True)        
+            await ctx.reply(embed=embed, mention_author=True)  
+        else:
+            pass      
                                 
                               
 

--- a/cogs/mhelp.py
+++ b/cogs/mhelp.py
@@ -1,0 +1,31 @@
+import discord
+from discord.ext import commands
+
+
+class Help(commands.Cog):
+    def __init__(self, bot):        
+        self.bot = bot
+
+    @commands.command(name = 'mhelp')
+    async def mhelp(self, ctx):
+        await ctx.send("""A simple Manim rendering bot.
+
+Use the `!manimate` command to render short and simple Manim scripts.
+Code **must** be properly formatted and indented. Note that you can't animate through DM's.
+
+Supported tags:
+```
+    -t, --transparent, -i, --save_as_gif, -s, --save_last_frame
+```
+Example:
+```
+!manimate -s
+\`\`\`py
+def construct(self):
+    self.play(ReplacementTransform(Square(), Circle()))
+\`\`\`
+```
+""")
+
+def setup(bot):
+    bot.add_cog(Help(bot))                            

--- a/cogs/mhelp.py
+++ b/cogs/mhelp.py
@@ -28,4 +28,4 @@ def construct(self):
 """)
 
 def setup(bot):
-    bot.add_cog(Help(bot))                            
+    bot.add_cog(Help(bot))

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
 PREFIX = '!'
 TOKEN = ''
-#Todo -- update class dictionary 
+#Todo -- update class dictionary
 BLACKLIST_COGS = {}
-

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+PREFIX = '!'
+TOKEN = ''
+#Todo -- update class dictionary 
+BLACKLIST_COGS = {}
+


### PR DESCRIPTION
I am testing the ability to search the Manim documentation using the requests-html library. So far, it is definitely doable but will take me some time to refactor the code since the embed limit can exceed if the request result is over the 2048 char limit. 

I have refactored the code according to the concept mentioned here: https://discordpy.readthedocs.io/en/stable/ext/commands/extensions.html

This is probably the best practice, making the code more readable and allowing future extensions. 
If you guys like the way it is right now, do let me know! I have some more ideas to make it more readable!

I was unable to test the !manimate command, it always errored out on my machine. I am sure someone can test it out. Do let me know if it works and if possible please make appropriate changes to make it work in case I missed anything.

Thank you, everyone! Let me know what you all think (:
