### PR TITLE
Patch mdoc (for real this time)

### DIFF
--- a/DiscordManimator.py
+++ b/DiscordManimator.py
@@ -201,7 +201,7 @@ async def mdoc(ctx, *args):
         await ctx.reply(f"Something went wrong: ```{e.args[0]}```")
         return
     
-    fqname = container_output.decode("utf-8").strip()
+    fqname = container_output.decode("utf-8").strip().splitlines()[2]
     url = f"https://docs.manim.community/en/stable/reference/{fqname}.html"
     await ctx.reply(f"Here you go: {url}")
     return


### PR DESCRIPTION
Patches mdoc; tested on my instance of the bot. The reason it was broken is that manim states "Manim Community 0.6.0" at every command; must have been something to do with the CLI switch. Only meant to be a quick patch while #11 is in progress.