### PR TITLE
Change black formatting line_length to 88.

### DIFF
--- a/DiscordManimator.py
+++ b/DiscordManimator.py
@@ -225,7 +225,7 @@ async def mdocstring(ctx, *, arg):
             extra_args += "\n    ".join(extra_args_lst)
 
         # format using black
-        max_line_length = 150
+        max_line_length = 88
         mode = black.FileMode(line_length=max_line_length)
         try:
             script = black.format_str(script, mode=mode)


### PR DESCRIPTION
https://github.com/ManimCommunity/manim/blob/005adf48e599ac5cbaf98ad8ae379da2974646cd/.flake8#L3

This is the value used by ManimCe to format code and should prevent excessive horizontal scrolling when viewing docs formatted using !mdocstring.