### PR TITLE
Added matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.7"
 python-dotenv = "^0.17"
 docker = "^5.0"
 black = {version = "^21.5b1", allow-prereleases = true}
+matplotlib = "^3.3.2"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
As Matplotlib has a lot of nice color maps, I suggest that we add this module to the bot:
https://matplotlib.org/stable/tutorials/colors/colormaps.html#miscellaneous 
Also, there are some useful color converting functions, that might be useful:
https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.colors.to_hex.html

I hope this is the right place to add this dependency.
