### PR TITLE
Readd `mdoc` command

### DIFF
--- a/cogs/manimate.py
+++ b/cogs/manimate.py
@@ -33,7 +33,9 @@ class Manimate(commands.Cog):
                 "--save_last_frame",
                 "-t",
                 "--transparent",
+                "--renderer=opengl"
             ]
+
             if not all([flag in allowed_flags for flag in cli_flags]):
                 reply_args = {
                     "content": "You cannot pass CLI flags other than "
@@ -41,8 +43,10 @@ class Manimate(commands.Cog):
                     "`-t` (`--transparent`)."
                 }
                 return reply_args
-            else:
-                cli_flags = " ".join(cli_flags)
+            if "--renderer=opengl" in cli_flags:
+                cli_flags.append("--write_to_movie")
+            cli_flags = " ".join(cli_flags)
+
 
             body = "\n".join(body).strip()
 

--- a/cogs/manimate.py
+++ b/cogs/manimate.py
@@ -40,7 +40,7 @@ class Manimate(commands.Cog):
                 reply_args = {
                     "content": "You cannot pass CLI flags other than "
                     "`-i` (`--save_as_gif`), `-s` (`--save_last_frame`), "
-                    "`-t` (`--transparent`)."
+                    "`-t` (`--transparent`), or `--renderer=opengl`."
                 }
                 return reply_args
             if "--renderer=opengl" in cli_flags:

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -1,96 +1,52 @@
-import asyncio
-
 import discord
-import nest_asyncio
+import os
+import docker
 from discord.ext import commands
-from requests_html import AsyncHTMLSession
 
-nest_asyncio.apply()
-
+dockerclient = docker.from_env()
 
 class Mdoc(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.base_link = "https://docs.manim.community/"
-        self.res = []
 
-    @commands.cooldown(1, 3, commands.BucketType.user)
     @commands.command(name="mdoc")
-    async def mdocs(self, ctx, *args):
-        if len(args) == 0 or len(args) > 1:
-            return await ctx.reply(
+    @commands.guild_only()
+    async def mdoc(self, ctx, *args):
+        if len(args) == 0:
+            await ctx.reply(
                 "Pass some manim function or class and I will find the "
                 "corresponding documentation for you. Example: `!mdoc Square`"
-                "Remember to not add any spaces."
             )
+            return
+
         arg = args[0]
-        self.res = []
-        pages = 0
         if not arg.isidentifier():
-            return await ctx.reply(
+            await ctx.reply(
                 f"`{arg}` is not a valid identifier, no class or function can be named like that."
             )
+            return
 
-        query_url = f"https://docs.manim.community/en/stable/search.html?q={arg}&check_keywords=yes&area=default#"
         try:
-            session = AsyncHTMLSession()
-            response = await session.get(query_url)
-        except:
-            return await ctx.send("`Failed to Establish Connection. Try again Later!`")
-        else:
-            await response.html.arender(sleep=2)
-            await session.close()
-            about = response.html.find(".search", first=True)
-            a = about.find("li")
-            pages = len(a)
-
-            if pages == []:
-                self.title = "`No Results Found`"
-            else:
-                self.title = f"`Results for: {arg}`"
-
-            for i in range(pages):
-                desc = (
-                    f'[`{a[i].text}`]({str(list(a[i].find("a")[0].absolute_links)[0])})'
-                )
-                embed = discord.Embed(
-                    title=self.title, description=desc, color=0xE8E3E3
-                )
-                self.res.append(embed)
-            cur_page = 0
-            reply_embed = await ctx.reply(
-                embed=self.res[cur_page], mention_author=False
+            container_output = dockerclient.containers.run(
+                image="manimcommunity/manim:stable",
+                command=f"""timeout 10 python -c "import manim; assert '{arg}' in dir(manim); print(manim.{arg}.__module__ + '.{arg}')" """,
+                user=os.getuid(),
+                stderr=False,
+                stdout=True,
+                detach=False,
+                remove=True,
             )
-            await reply_embed.add_reaction("◀️")
-            await reply_embed.add_reaction("▶️")
-            await reply_embed.add_reaction("\U0001F5D1")
+        except docker.errors.ContainerError as e:
+            if "AssertionError" in e.args[0]:
+                await ctx.reply(f"I could not find `{arg}` in our documentation, sorry.")
+                return
+            await ctx.reply(f"Something went wrong: ```{e.args[0]}```")
+            return
 
-            while True:
-                try:
-                    reaction, user = await self.bot.wait_for(
-                        "reaction_add",
-                        check=lambda reaction, user: user == ctx.author
-                        and str(reaction.emoji) in ["◀️", "▶️", "\U0001F5D1"],
-                        timeout=60,
-                    )
-                    if str(reaction.emoji) == "▶️" and cur_page != pages:
-                        cur_page += 1
-                        await reply_embed.edit(embed=self.res[cur_page])
-                        await reply_embed.remove_reaction(reaction, ctx.author)
-
-                    elif str(reaction.emoji) == "◀️" and cur_page > 0:
-                        cur_page -= 1
-                        await reply_embed.edit(embed=self.res[cur_page])
-                        await reply_embed.remove_reaction(reaction, ctx.author)
-
-                    elif str(reaction.emoji) == "\U0001F5D1":
-                        await reply_embed.delete()
-                    else:
-                        await reply_embed.remove_reaction(reaction, ctx.author)
-
-                except asyncio.TimeoutError:
-                    await reply_embed.clear_reactions()
-
+        fqname = container_output.decode("utf-8").strip().splitlines()[2]
+        url = f"https://docs.manim.community/en/stable/reference/{fqname}.html"
+        await ctx.reply(f"Here you go: {url}")
+        return
 
 def setup(bot):
     bot.add_cog(Mdoc(bot))

--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -1,4 +1,3 @@
-import discord
 import os
 import docker
 from discord.ext import commands

--- a/cogs/msearch.py
+++ b/cogs/msearch.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import discord
+import nest_asyncio
+from discord.ext import commands
+from requests_html import AsyncHTMLSession
+
+nest_asyncio.apply()
+
+
+class Msearch(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.base_link = "https://docs.manim.community/"
+        self.res = []
+
+    @commands.cooldown(1, 3, commands.BucketType.user)
+    @commands.command(name="msearch", aliases=["ms"])
+    async def msearch(self, ctx, *args):
+        if len(args) == 0 or len(args) > 1:
+            return await ctx.reply(
+                "Pass some manim function or class and I will find the "
+                "corresponding documentation for you. Example: `!msearch Square`"
+                "Remember to not add any spaces."
+            )
+        arg = args[0]
+        self.res = []
+        pages = 0
+        if not arg.isidentifier():
+            return await ctx.reply(
+                f"`{arg}` is not a valid identifier, no class or function can be named like that."
+            )
+
+        query_url = f"https://docs.manim.community/en/stable/search.html?q={arg}&check_keywords=yes&area=default#"
+        try:
+            session = AsyncHTMLSession()
+            response = await session.get(query_url)
+        except:
+            return await ctx.send("`Failed to Establish Connection. Try again Later!`")
+        else:
+            await response.html.arender(sleep=2)
+            await session.close()
+            about = response.html.find(".search", first=True)
+            a = about.find("li")
+            pages = len(a)
+
+            if pages == []:
+                self.title = "`No Results Found`"
+            else:
+                self.title = f"`Results for: {arg}`"
+
+            for i in range(pages):
+                desc = (
+                    f'[`{a[i].text}`]({str(list(a[i].find("a")[0].absolute_links)[0])})'
+                )
+                embed = discord.Embed(
+                    title=self.title, description=desc, color=0xE8E3E3
+                )
+                self.res.append(embed)
+            cur_page = 0
+            reply_embed = await ctx.reply(
+                embed=self.res[cur_page], mention_author=False
+            )
+            await reply_embed.add_reaction("◀️")
+            await reply_embed.add_reaction("▶️")
+            await reply_embed.add_reaction("\U0001F5D1")
+
+            while True:
+                try:
+                    reaction, user = await self.bot.wait_for(
+                        "reaction_add",
+                        check=lambda reaction, user: user == ctx.author
+                        and str(reaction.emoji) in ["◀️", "▶️", "\U0001F5D1"],
+                        timeout=60,
+                    )
+                    if str(reaction.emoji) == "▶️" and cur_page != pages:
+                        cur_page += 1
+                        await reply_embed.edit(embed=self.res[cur_page])
+                        await reply_embed.remove_reaction(reaction, ctx.author)
+
+                    elif str(reaction.emoji) == "◀️" and cur_page > 0:
+                        cur_page -= 1
+                        await reply_embed.edit(embed=self.res[cur_page])
+                        await reply_embed.remove_reaction(reaction, ctx.author)
+
+                    elif str(reaction.emoji) == "\U0001F5D1":
+                        await reply_embed.delete()
+                    else:
+                        await reply_embed.remove_reaction(reaction, ctx.author)
+
+                except asyncio.TimeoutError:
+                    await reply_embed.clear_reactions()
+
+
+def setup(bot):
+    bot.add_cog(Msearch(bot))


### PR DESCRIPTION
As the new implementation of `!mdoc` involving searching the documentation isn't quite ready, I've readded the old `!mdoc` command and renamed the new `!mdoc` to `!msearch`. This will allow us to move to using the refactor branch now.