### PR TITLE
Better searching for documentation

### DIFF
--- a/cogs/mdoc.py
+++ b/cogs/mdoc.py
@@ -74,7 +74,7 @@ class Mdoc(commands.Cog):
                 )
 
                 if method_or_attribute:
-                    method_absence = dockerclient.containers.run(
+                    dockerclient.containers.run(
                         image="manimcommunity/manim:stable",
                         command=f"""timeout 10 python -c "import manim; assert hasattr(manim.{object_or_class}, '{method_or_attribute}')" """,
                         user=os.getuid(),


### PR DESCRIPTION
mdoc can now search for functions and attributes as well.
Usage:
`!mdoc <class_name>.[method_or_attribute]`

mdoc can now also show the docs of a particular version of manim (including latest and stable)
Closes #10
Usage:
`!mdoc <class_name>.[method_or_attribute] <version>`
Example:
`!mdoc Mobject.add v0.2.0`
`!mdoc Polygon latest`